### PR TITLE
Add trial.py with basic sketch of Trial class.

### DIFF
--- a/spike2py/trial.py
+++ b/spike2py/trial.py
@@ -1,0 +1,36 @@
+import os
+
+
+class Trial:
+    """Class for experimental trial recorded using Spike2."""
+
+    def __init__(self, file, name=None, subject_id=None, channels='All'):
+        """
+
+        Parameters
+        ----------
+        file: str
+            Absolute path to data file. Only .mat files are currently supported.
+        name: str (Default: name of file)
+            Descriptive name of trial.
+        subject_id: str
+            Subject's study identifier
+        channels: list
+            List of channel names, as they appeared in the original .smr file.
+            Example: ['biceps', 'triceps', 'torque']
+            If not included, all channels will be processed.
+
+        """
+        if name is None:
+            name = os.path.split(file)[-1].split('.')[0]
+        self.name = name
+        self.file = file
+        self.subject_id = subject_id
+        self.channels = channels
+        #TODO: Update read.py and test_read.py based on `channels` default being 'All', which is more informative.
+        self._import_trial_data(file, channels)
+
+    def _import_trial_data(self):
+        pass
+
+


### PR DESCRIPTION
Again, wanted to flesh out a few of the pieces that will be needed. 

Each instance of the `Trial` class will represent a real-world experimental trial. It will contain some basic information about the trial. It will also contained the imported channel data (method template created but not yet implemented).

I decided to not go any further because I was not 100% certain how to proceed. 

-----------------------

In my previous version of this code, the various channels were located in a dictionary, which was an attribute of the Trial class. For example, you would access the 'knee_torque' channel as follows:

```python
max_ext1.signals['knee_torque']
```  
[Note: My new version of the code has replaced 'signals' with 'channels' to better reflect the terminology used by Spike2.]

I found my previous interface clunky. Because the channels were in a dict, you could not used code completion to access the individual channels. That is, you could not hit Tab and get suggestions from the IDE; you had to remember the exact name of the channel.

In this new iteration of the code, I would like the channels to become attributes of the class. This would allow:

max_ext1.<Tab>

Which, as is typical, would suggest all Class attributes and methods, including the available channels. For example:

```python
max_ext1.knee_torque
```

When I wrote my first version of this code, I did not know about `settatr`, which if I am correct, will allow me to set the attribute name to the actual channel name (e.g. 'knee_torque').

Does this approach seem sensible/feasible?
